### PR TITLE
Bump Nimble to 14.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "941ec0f40877766b422ded3383ff2d2a7dc2aad9fc8e64b9cc69e3d43c928d0f",
+  "originHash" : "2ce7824c659421d3a0b05481ca9a0d0ea61d81e9364980bc71868dc7b8e7c21a",
   "pins" : [
     {
       "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "cc945f7bdf3b485adedc315e18685c065059b4ca",
-        "version" : "13.8.0"
+        "revision" : "035b88ad6ae8035f5ce2b50b0a6d69c3b16d2120",
+        "version" : "14.0.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",
       "state" : {
-        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
-        "version" : "1.4.6"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/malcommac/SwiftScanner.git", from: "1.1.0"),
     .package(url: "https://github.com/Quick/Quick.git", from: "7.6.2"),
-    .package(url: "https://github.com/Quick/Nimble.git", from: "13.7.1"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "14.0.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.3"),
     .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.8.4")
   ],


### PR DESCRIPTION
No test changes required; this project does not use the deprecated
sync polling expectations or waitUntil from Swift.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
