### PR TITLE
Modern Swift concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.0.1] - 2026-06-26
+
+### Changed
+
+- Adopted the Approachable Concurrency upcoming features
+  (`NonisolatedNonsendingByDefault`, `InferIsolatedConformances`). The library
+  is fully synchronous, so there is no change to the public API or behavior.
+
 ## [1.0.0] - 2024-04-03
 
 Initial release.

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,11 @@
 
 import PackageDescription
 
+let approachableConcurrency: [SwiftSetting] = [
+  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+  .enableUpcomingFeature("InferIsolatedConformances")
+]
+
 let package = Package(
   name: "GarminACE",
   defaultLocalization: "en",
@@ -23,12 +28,14 @@ let package = Package(
     .target(
       name: "GarminACE",
       dependencies: ["SwiftScanner", "CryptoSwift"],
-      resources: [.process("Localizable.xcstrings")]
+      resources: [.process("Localizable.xcstrings")],
+      swiftSettings: approachableConcurrency
     ),
     .testTarget(
       name: "GarminACETests",
       dependencies: ["GarminACE", "Nimble", "Quick"],
-      resources: [.copy("Resources")]
+      resources: [.copy("Resources")],
+      swiftSettings: approachableConcurrency
     )
   ],
   swiftLanguageModes: [.v5, .v6]


### PR DESCRIPTION
## Summary

Opts the GarminACE library and test targets into the Approachable Concurrency
upcoming features:

- `NonisolatedNonsendingByDefault`
- `InferIsolatedConformances`

The package is purely synchronous (no `async`/`await`, no actor-isolated
types), so these flags are inert for the current public API — they simply
align the targets with Swift's modern concurrency defaults going forward.

## Verification

- `swift build --build-tests` succeeds.
- Unit tests pass.

## Version

This release is `1.0.1` (patch — no public API or behavioral change). The
GitHub release will be cut after this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
